### PR TITLE
Add https protocol to request URLs

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -22,18 +22,18 @@
 
 		<link rel="shortcut icon" href="assets/img/favicon.png">
 
-		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Assistant:regular,bold,extra-light|Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-		<link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-		<link rel="stylesheet" href="//code.getmdl.io/1.1.3/material.indigo-amber.min.css">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Assistant:regular,bold,extra-light|Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+		<link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.indigo-amber.min.css">
 		<link rel="stylesheet" href="assets/css/styles.css">
 
-		<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react-dom.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment-with-locales.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.1.3/material.min.js"></script>
+		<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react-dom.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment-with-locales.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.1.3/material.min.js"></script>
 		<script src="assets/js/config.js"></script>
 		<script src="assets/js/utils.js"></script>
 		<script src="assets/js/translations.js"></script>


### PR DESCRIPTION
Decreases loading time by approx 600ms by eliminating redirects. Also improves security.

>Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the `https://` asset.
Allowing the snippet to request over HTTP opens the door for attacks like the recent Github Man-on-the-side attack. It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is not true.

https://www.paulirish.com/2010/the-protocol-relative-url/